### PR TITLE
[package.json] repository/urlをhttpsにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/prh/vscode-prh-extention.git"
+        "url": "https://github.com/prh/vscode-prh-extention.git"
     },
     "author": "vvakame",
     "license": "MIT",


### PR DESCRIPTION
このフィールドはvscode拡張のページでブラウザを開くリンクになるので、
`git+https:`になっているとvscodeから開けなくなり、次のエラーになってしまう

> Unable to open 'vscode-prh-extention.git': Unable to resolve resource git+https://github.com/prh/vscode-prh-extention.git.

`https`にするとよさそうです。